### PR TITLE
Support old versions of microhttpd (<0.9.43)

### DIFF
--- a/libsyndicate/httpd.h
+++ b/libsyndicate/httpd.h
@@ -69,6 +69,11 @@ using namespace std;
 #include "libsyndicate/libsyndicate.h"
 #include "microhttpd.h"
 
+// Support old versions of microhttpd (< 0.9.43)
+#if MHD_VERSION < 0x00094300
+#define MHD_create_response_from_fd_at_offset64         MHD_create_response_from_fd_at_offset
+#endif
+
 #define SG_HTTP_TMPFILE_FORMAT          "/tmp/.syndicate-upload.XXXXXX"
 
 // HTTP headers


### PR DESCRIPTION
This change makes Syndicate compilable with older versions of microhttpd. 
It simply redefines the 64bit operation we use and redirects to an old function.