### PR TITLE
Bugfix - helper_env should not be empty.

### DIFF
--- a/gateways/acquisition/crawl.cpp
+++ b/gateways/acquisition/crawl.cpp
@@ -289,7 +289,6 @@ static int AG_crawl_create( struct AG_state* core, char const* path, struct md_e
 
    // try to create or mkdir 
    if( ent->type == MD_ENTRY_FILE ) {
-
        clock_gettime( CLOCK_REALTIME, &now );
 
        ent->manifest_mtime_sec = now.tv_sec;
@@ -301,7 +300,6 @@ static int AG_crawl_create( struct AG_state* core, char const* path, struct md_e
 
        h = UG_publish( ug, path, ent, &rc );
        if( h == NULL ) {
-
           SG_error("UG_publish(%s) rc = %d\n", path, rc );
           goto AG_crawl_create_out;
        }
@@ -317,18 +315,14 @@ static int AG_crawl_create( struct AG_state* core, char const* path, struct md_e
 
        close_rc = UG_close( ug, h );
        if( close_rc != 0 ) {
-
           SG_error("UG_close(%s) rc = %d\n", path, close_rc );
        }
        
        h = NULL;
    }
-
    else {
-
       rc = UG_mkdir( ug, path, ent->mode );
       if( rc != 0 ) {
-         
          SG_error("UG_mkdir(%s) rc = %d\n", path, rc );
          goto AG_crawl_create_out;         
       }
@@ -336,7 +330,7 @@ static int AG_crawl_create( struct AG_state* core, char const* path, struct md_e
 
 AG_crawl_create_out:
    
-   if( rc != -ENOMEM && rc != -EPERM && rc != -EACCES && rc != -EEXIST && rc != -ENOENT ) {
+   if( rc != 0 && rc != -ENOMEM && rc != -EPERM && rc != -EACCES && rc != -EEXIST && rc != -ENOENT ) {
        rc = -EREMOTEIO;
    }
    return rc;

--- a/libsyndicate/libsyndicate.cpp
+++ b/libsyndicate/libsyndicate.cpp
@@ -2833,6 +2833,12 @@ int md_default_conf( struct md_syndicate_conf* conf ) {
    conf->certs_reload_helper = SG_strdup_or_die( SG_DEFAULT_CERTS_RELOAD_HELPER );
    conf->driver_reload_helper = SG_strdup_or_die( SG_DEFAULT_DRIVER_RELOAD_HELPER );
 
+   // create a NULL terminated empty array (in length 1)
+   conf->helper_env = SG_CALLOC( char*, 1 );
+   if( conf->helper_env == NULL ) {
+      exit(1);
+   }
+
    return 0;
 }
 


### PR DESCRIPTION
An empty (NULL) helper_env field causes a segmentation fault in SG_proc_start.
SG_proc_start function in proc.cpp does not check if the field is empty.