### PR TITLE
Allow local MS (development) publically accessible

### DIFF
--- a/docker/gateways/Dockerfile.template
+++ b/docker/gateways/Dockerfile.template
@@ -69,7 +69,7 @@ RUN make install
 WORKDIR $HOME/syndicate/gateways/user
 RUN make install
 
-expose 31111
+expose $GATEWAY_PORT$
 
 USER syndicate
 WORKDIR $HOME

--- a/docker/gateways/README.md
+++ b/docker/gateways/README.md
@@ -10,11 +10,16 @@ Run build.sh to start building a docker image.
 sudo build.sh
 ```
 
+You can also specify a port number you want to use for the gateway and a name of docker image.
+```
+sudo build.sh 31112 syndicate-gateways-31112
+```
+
+
 A new docker image for Syndicate Gateway will have a name "syndicate-gateways" by default. The docker image created will have Syndicate installed and an user "syndicate".
 
 You can run the image in interactive mode by following command.
 ```
 sudo docker run -t -i -p 31111:31111 syndicate-gateways
 ```
-
 

--- a/docker/gateways/build.sh
+++ b/docker/gateways/build.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+GATEWAY_PORT=31111
+IMAGE_NAME="syndicate-gateways"
+if [ "$#" -ge 1 ]; then
+    GATEWAY_PORT=$1
+fi
 
-#docker build --no-cache -t docker-gateways .
-docker build -t syndicate-gateways .
+if [ "$#" -ge 2 ]; then
+    IMAGE_NAME=$2
+fi
+
+# copy from template
+cp Dockerfile.template Dockerfile
+PARAM='s/\$GATEWAY_PORT\$/'$GATEWAY_PORT'/g'
+sed -i $PARAM Dockerfile
+
+#docker build --no-cache -t $IMAGE_NAME .
+docker build -t $IMAGE_NAME .

--- a/docker/ms/Dockerfile.template
+++ b/docker/ms/Dockerfile.template
@@ -56,6 +56,10 @@ RUN wget -O syndicate.zip https://github.com/jcnelson/syndicate/archive/master.z
 RUN unzip syndicate.zip
 RUN mv syndicate-master syndicate
 WORKDIR "syndicate"
+
+# replace localhost to $MS_HOST$
+RUN sed -i 's/localhost/$MS_HOST$/g' ms/common/msconfig.py
+
 RUN make MS_APP_ADMIN_EMAIL=$MS_APP_ADMIN_EMAIL$
 RUN echo "======== SYNDICATE ADMIN INFO ========"
 RUN cat build/out/ms/common/admin_info.py

--- a/docker/ms/build.sh
+++ b/docker/ms/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 admin_email"
-    exit 1
+ADMIN_EMAIL=""
+MS_HOST="localhost"
+if [ "$#" -ge 1 ]; then
+    ADMIN_EMAIL=$1
+fi
+
+if [ "$#" -ge 2 ]; then
+    MS_HOST=$2
 fi
 
 # copy from template
 cp Dockerfile.template Dockerfile
-PARAM='s/\$MS_APP_ADMIN_EMAIL\$/'$1'/g'
+PARAM='s/\$MS_APP_ADMIN_EMAIL\$/'$ADMIN_EMAIL'/g'
+sed -i $PARAM Dockerfile
+PARAM='s/\$MS_HOST\$/'$MS_HOST'/g'
 sed -i $PARAM Dockerfile
 
 #docker build --no-cache -t docker-ms .


### PR DESCRIPTION
Allow local MS (development) publically accessible by modifying msconfig.py.
Take port parameter from a build script of gateway docker image.